### PR TITLE
UI improvement for landing page

### DIFF
--- a/src/components/CompetitionTable.css
+++ b/src/components/CompetitionTable.css
@@ -1,0 +1,47 @@
+@media (max-width: 1040px) {
+  .compTable{
+    width: 100%;
+    margin: auto;
+    border-collapse: collapse;
+  }
+}
+@media (min-width: 1041px) {
+  .compTable{
+    width: 70%;
+    margin: auto;
+    /* margin: -40px; */
+    border-collapse: collapse;
+  }
+}
+.comp {
+  justify-content: center;
+  align-items: center;
+}
+.compRow {
+  transition: background-color 0.2s;
+}
+.compRow:nth-child(odd) {
+  background-color: #e2e2e2;
+}
+.compName {
+  width: 30%;
+}
+.compCity {
+  width: 30%;
+}
+.venue {
+  font-style: italic;
+}
+.compDate {
+  width: 30%;
+}
+.compLinks:link, .compLinks:visited {
+  text-decoration: none;
+  color: #d30000;
+}
+.compRow:hover {
+  background-color: #c2c2c2;
+}
+.Main {
+  margin-bottom: 10%;
+}

--- a/src/components/CompetitionTable.tsx
+++ b/src/components/CompetitionTable.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { compResponse } from '../types';
+import './CompetitionTable.css';
+
+export function CompetitionTable() {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [norwayCompData, setNorwayCompData] = useState<compResponse[]>([]);
+  const [worldCompData, setWorldCompData] = useState<compResponse[]>([]);
+
+  const getCompData = async(): Promise<void> => {
+    setLoading(true);
+    try {
+      await axios.get(`${process.env.REACT_APP_KONKURRANSE_KEY}`)
+        .then(response => setNorwayCompData(response.data));
+      await axios.get(`${process.env.REACT_APP_VERDENSKONKURRANSE_KEY}`)
+        .then(response => setWorldCompData(response.data));
+
+    } catch (error) {
+      let message: string;
+      if (error instanceof Error) {
+        message = error.message;
+      } else {
+        message = String(error);
+      }
+      alert(message);
+    }
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    getCompData();
+  }, []);
+
+  worldCompData.splice(1);
+  let compData = norwayCompData.concat(worldCompData);
+  compData.sort((a, b) => new Date(a.start_date).getTime() - new Date(b.start_date).getTime());
+
+  const comingComps = () => {
+  return(
+    <table className="compTable">
+      <thead>
+        <tr>
+          <th>Navn</th>
+          <th>Sted</th>
+          <th>Dato</th>
+        </tr>
+      </thead>
+      <tbody className="comp">{compData.map((comp: any) => {
+        let compDate;
+        let compElStart = new Date(comp.start_date);
+        let compElEnd = new Date(comp.end_date);
+        // let compVenue = comp.venue.replace(/ *\([^)]*\) */g, "").replace("[", "").replace("]", "");
+        if (Date.parse(comp.start_date) === Date.parse(comp.end_date)){
+          compDate = compElStart.getDate() + " " + compElStart.toLocaleDateString("en-GB", {month: 'short'});
+        }
+        else {
+          compDate = compElStart.getDate() + " " + compElStart.toLocaleDateString("en-GB", {month: 'short'}) + " - "  +
+          compElEnd.getDate() + " " + compElEnd.toLocaleDateString("en-GB", {month: 'short'});
+        }
+        if(Date.parse(comp.end_date) > Date.now()){
+          return(
+            <tr className="compRow" key={comp.id}>
+              <td className="compName"><a href={comp.url} className="compLinks">{comp.name}</a></td>
+              <td className="compCity">{comp.city}</td>
+              <td className="compDate">{compDate}</td>
+            </tr>
+          )
+        }
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+  //render
+  return (
+        <div className="Comps">
+          {comingComps()}
+          {loading && <p>Laster inn...</p>}
+        </div>
+  )
+}
+
+export default CompetitionTable;

--- a/src/pages/App.css
+++ b/src/pages/App.css
@@ -5,11 +5,50 @@ body {
   .Main {
     margin: auto;
     width: 93%;
+    padding-bottom: 20px;
   }
+
+  .HomeHeader {
+    color: #d30000;
+  }
+
+  .CompetitionHeader {
+    color: #d30000;
+  }
+
 }
 @media (min-width: 1041px) {
   .Main {
     margin: auto;
-    width: 70%;
+    width: 93%;
+    padding-bottom: 20px;
   }
+
+  .HomeHeader {
+    color: #d30000;
+    justify-content: left;
+    text-align: justify;
+  }
+
+  .CompetitionHeader {
+    color: #d30000;
+  }
+
+  .content {
+    justify-content: left;
+    text-align: justify;
+  }
+
+  .column {
+    float: left;
+    width: 50%;
+  }
+
+  /* Clear floats after the columns */
+  .row:after {
+    content: "";
+    display: table;
+    clear: both;
+  }
+
 }

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import './App.css';
-import { Link } from 'react-router-dom';
+import { CompetitionTable } from '../components/CompetitionTable';
 
 
 function App(): React.ReactElement<any, any> {
@@ -8,14 +8,11 @@ function App(): React.ReactElement<any, any> {
   return (
     <div className="App">
       <div className='Main'>
-        <div className='Intro'>
-          <h1 className='MainHeader'>Hjem</h1>
-        </div>
-        <div className='MainBody'>
+        <div className='column'>
           <div className='HomeElements'>
             <div className='Main'>
-              <h2>Velkommen</h2>
-              <body>
+              <h2 className='HomeHeader'>Norges Kubeforbund</h2>
+              <body className='content'>
                 Velkommen til hjemmesiden til Norges kubeforbund.
                 Hvis du ønsker å lære deg å løse Rubiks kube, så har du kommet til riktig sted.
                 Vi har guider som beskriver hvordan dette gjøres.
@@ -24,18 +21,21 @@ function App(): React.ReactElement<any, any> {
                 så har du også kommet til riktig sted.
                 Her kan du finne informasjon om norske konkurranser og andre arrangementer.
               </body>
-              <h2>Hva er 'speedcubing'?</h2>
-              <body>
+              <br></br>
+              <h2 className='HomeHeader'>Hva er speedkubing?</h2>
+              <body className='content'>
                 Speedcubing er en sport hvor målet er å løse Rubiks kube og andre liknende puslespill på kortest mulig tid.
                 Flere ganger årlig arrangeres det konkurranser i Norge (og i resten av verden),
                 hvor deltakerne løser Rubiks kube på tid.
               </body>
-              <h2>Kommende konkurranser</h2>
-              <body>
-                Kommende konkurranser finner du <Link to='/konkurranser'>her.</Link>
-              </body>
             </div>
           </div>
+        </div>
+        <div className='column'>
+          <h2 className='CompetitionHeader'>Kommende Konkurranser</h2>
+          <body>
+            {CompetitionTable()}
+          </body>
         </div>
       </div>
     </div>


### PR DESCRIPTION
I have updated the layout of the landing page. The main change is the addition of a table with upcoming WCA competitions on the landing page itself. This table only contain upcoming events, and not previous competitions unlike what's shown on the kubing.no/konkurranser page.

The code for the competition table on the landing page is stored in the components folder. The intention is to update the looks of this at a later point.